### PR TITLE
Fix build for legacy theme

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -7,6 +7,7 @@ export const Config = {
   GTAG_PETITION_CREATE: process.env.GTAG_PETITION_CREATE,
   ONLY_PROD_ROUTES: process.env.ONLY_PROD_ROUTES || '',
   SESSION_COOKIE_NAME: process.env.SESSION_COOKIE_NAME || '',
+  THEME: process.env.THEME || '',
   TRACK_SHARE_URL: process.env.TRACK_SHARE_URL || '',
   USE_HASH_BROWSING: process.env.USE_HASH_BROWSING || process.env.NODE_ENV === 'test',
   STATIC_ROOT: process.env.STATIC_ROOT,

--- a/src/containers/create.js
+++ b/src/containers/create.js
@@ -8,10 +8,10 @@ import { withRouter } from 'react-router'
 import Config from '../config'
 
 import { previewSubmit, submit, devLocalSubmit } from '../actions/createPetitionActions'
-import { conversation } from 'Theme/etc/conversation/conversation' // eslint-disable-line
+import { conversation } from 'GiraffeTheme/etc/conversation/conversation'
 
-import CreatePetitionForm from 'Theme/etc/create-petition-form' // eslint-disable-line
-import CreatePetitionFormConversation from 'Theme/etc/create-petition-form-conversation' // eslint-disable-line
+import CreatePetitionForm from 'GiraffeTheme/etc/create-petition-form'
+import CreatePetitionFormConversation from 'GiraffeTheme/etc/create-petition-form-conversation'
 
 import { isValidEmail } from '../lib'
 

--- a/src/routes.js
+++ b/src/routes.js
@@ -131,9 +131,11 @@ export const routes = store => {
       <Route path='thanks.html' component={ThanksShim} prodReady minimalNav />
       <Route path=':organization/thanks.html' component={ThanksShim} onEnter={orgLoader} prodReady minimalNav />
       <Route path='find' component={LoadableSearch} />
+
+      {Config.THEME === 'giraffe' && <Route path='create' component={LoadableCreatePetition} minimalNav />}
+      {Config.THEME === 'giraffe' && <Route path='create/:type' component={LoadableCreatePetition} minimalNav />}
+
       <Route path='create_start.html' component={LoadableCreate} minimalNav />
-      <Route path='create' component={LoadableCreatePetition} minimalNav />
-      <Route path='create/:type' component={LoadableCreatePetition} minimalNav />
       <Route path='create_preview.html' component={LoadablePreview} minimalNav />
       <Route path='create_revise.html' component={LoadableRevise} minimalNav />
       <Route path='create_finished.html' component={LoadableFinished} minimalNav />

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,6 +23,7 @@ var envVars = {
   'ONLY_PROD_ROUTES': process.env.ONLY_PROD_ROUTES || '',
   'SESSION_COOKIE_NAME': process.env.SESSION_COOKIE_NAME || 'SO_SESSION',
   'STATIC_ROOT': process.env.STATIC_ROOT || '/local/',
+  'THEME': THEME,
   'TRACK_SHARE_URL': process.env.TRACK_SHARE_URL || '',
   'USE_HASH_BROWSING': process.env.USE_HASH_BROWSING || false,
   'PROD': process.env.PROD,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -130,6 +130,7 @@ var config = {
     alias: {
       Theme: THEME_DIR,
       LegacyTheme: path.resolve(__dirname, "src/components/theme-legacy/"),
+      GiraffeTheme: path.resolve(__dirname, "src/components/theme-giraffe/"),
       GiraffeUI: path.resolve(__dirname, "src/giraffe-ui")
     }
   },


### PR DESCRIPTION
It wasn't possible to build using the legacy theme. I fixed that in the first commit.

I also disabled the /create route for the legacy theme. The routes are looking a little messy with all the versions of create, but this is probably something we can fix later.