### PR TITLE
Remove body css from create.scss and instead depend on wrapper

### DIFF
--- a/css/create.scss
+++ b/css/create.scss
@@ -1,5 +1,4 @@
 $white: #ffffff;
-$off-white: #f3f3f3;
 $gray: #cacaca;
 $light-gray: #a7a7a7;
 $slate-gray: #696a6a;
@@ -17,23 +16,10 @@ $bp-sm: 0px;
 $bp-md: 768px;
 $bp-lg: 1008px;
 $bp-xl: 1440px;
-body {
-    background-color: $off-white;
-    overflow-x: hidden;
-}
 
 hr {
     border-top: 5px solid gray;
     margin: 20px 0;
-}
-
-.giraffe body,
-.giraffe#giraffe-wrapper {
-    padding-top: 0;
-}
-
-.giraffe .header {
-    display: none !important;
 }
 
 /****************
@@ -874,12 +860,6 @@ hr {
     }
 }
 
-
-
-#footer {
-    display: none !important;
-}
-
 /* Conversational */
 
 #conversational-top {
@@ -897,12 +877,6 @@ hr {
       position: relative;
       left: 50%;
       transform: translateX(-50%);
-  }
-}
-
-@media screen and (min-width: $bp-md) {
-  #conversational-top {
-
   }
 }
 

--- a/src/components/theme-giraffe/wrapper.js
+++ b/src/components/theme-giraffe/wrapper.js
@@ -1,13 +1,32 @@
 import React from 'react'
+import cx from 'classnames'
 import PropTypes from 'prop-types'
 import Nav from '../../containers/nav'
 import Footer from 'Theme/footer'
 
-const Wrapper = ({ children, organization, minimalNav, entity }) => (
-  <div id='giraffe-wrapper' className='giraffe petition'>
-    <Nav organization={organization} minimal={minimalNav} entity={entity} />
-    <main id='content'>{children}</main>
-    <Footer entity={entity} />
+const Wrapper = ({
+  children,
+  organization,
+  minimalNav,
+  hideNav,
+  hideFooter,
+  offWhiteBg,
+  entity
+}) => (
+  <div className='giraffe'>
+    <div
+      id='giraffe-wrapper'
+      className={cx('giraffe', 'petition', {
+        'bg-off-white': offWhiteBg,
+        'pt-0': hideNav
+      })}
+    >
+      {!hideNav && (
+        <Nav organization={organization} minimal={minimalNav} entity={entity} />
+      )}
+      <main id='content'>{children}</main>
+      {!hideFooter && <Footer entity={entity} />}
+    </div>
   </div>
 )
 
@@ -15,6 +34,9 @@ Wrapper.propTypes = {
   children: PropTypes.node.isRequired,
   organization: PropTypes.string,
   minimalNav: PropTypes.bool,
+  hideNav: PropTypes.bool,
+  hideFooter: PropTypes.bool,
+  offWhiteBg: PropTypes.bool,
   entity: PropTypes.string
 }
 

--- a/src/containers/wrapper.js
+++ b/src/containers/wrapper.js
@@ -56,6 +56,9 @@ class Wrapper extends React.Component {
       <WrapperComponent
         entity={entity}
         minimalNav={hasRouteBool('minimalNav', routes)}
+        hideNav={hasRouteBool('hideNav', routes)}
+        hideFooter={hasRouteBool('hideFooter', routes)}
+        offWhiteBg={hasRouteBool('offWhiteBg', routes)}
       >
         {error.response_code === 404 && <Error404 error={error} />}
         {error.response_code === 500 && <Error500 error={error} />}

--- a/src/routes.js
+++ b/src/routes.js
@@ -132,8 +132,8 @@ export const routes = store => {
       <Route path=':organization/thanks.html' component={ThanksShim} onEnter={orgLoader} prodReady minimalNav />
       <Route path='find' component={LoadableSearch} />
 
-      {Config.THEME === 'giraffe' && <Route path='create' component={LoadableCreatePetition} minimalNav />}
-      {Config.THEME === 'giraffe' && <Route path='create/:type' component={LoadableCreatePetition} minimalNav />}
+      {Config.THEME === 'giraffe' && <Route path='create' component={LoadableCreatePetition} hideNav hideFooter offWhiteBg />}
+      {Config.THEME === 'giraffe' && <Route path='create/:type' component={LoadableCreatePetition} hideNav hideFooter offWhiteBg />}
 
       <Route path='create_start.html' component={LoadableCreate} minimalNav />
       <Route path='create_preview.html' component={LoadablePreview} minimalNav />


### PR DESCRIPTION
Removes the major conflicting css from create.scss, so that once it gets applied, there are no issues if another page is loaded within the app (e.g. by going back). I replace it with "route booleans" in the wrapper, which applies classnames from the normal giraffe bundle.

It's still probably a good idea to nest some of the other css to ensure no conflicts, but we'll do that in another pr.